### PR TITLE
Add basic external storage browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 This sample demonstrates basic USB interaction and browsing of external
 storage connected to the device. The main screen lists any directories
 under `/storage` that are not part of the internal system storage. Tapping
-one opens a file browser where you can add, delete or rename files.
+one opens a file browser where you can add, delete or rename files. When
+adding a file you can browse the external storage to choose the exact
+destination directory.
 
 The app uses the `permission_handler` plugin to request storage access.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@ storage connected to the device. The main screen lists any directories
 under `/storage` that are not part of the internal system storage. Tapping
 one opens a file browser where you can add, delete or rename files.
 
+### Android NDK version
+
+The `usb_serial` plugin requires Android NDK `27.0.12077973`. If you see a
+build failure mentioning a mismatched NDK version, update
+`android/app/build.gradle.kts`:
+
+```kotlin
+android {
+    ndkVersion = "27.0.12077973"
+}
+```
+
 ## Getting Started
 
 This project is a starting point for a Flutter application.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # my_flutter_app
 
-A new Flutter project.
+This sample demonstrates basic USB interaction and browsing of external
+storage connected to the device. The main screen lists any directories
+under `/storage` that are not part of the internal system storage. Tapping
+one opens a file browser where you can add, delete or rename files.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ android {
 
 ### Storage permissions
 
-The sample scans `/storage` for removable media. Grant the Storage
+The sample scans `/storage` for removable media. Items are displayed alphabetically. Grant the Storage
 permission on first launch so the app can access external files.
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ storage connected to the device. The main screen lists any directories
 under `/storage` that are not part of the internal system storage. Tapping
 one opens a file browser where you can add, delete or rename files.
 
+The app uses the `permission_handler` plugin to request storage access.
+
 ### Android NDK version
 
 The `usb_serial` plugin requires Android NDK `27.0.12077973`. If you see a
@@ -16,6 +18,11 @@ android {
     ndkVersion = "27.0.12077973"
 }
 ```
+
+### Storage permissions
+
+The sample scans `/storage` for removable media. Grant the Storage
+permission on first launch so the app can access external files.
 
 ## Getting Started
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,7 +8,8 @@ plugins {
 android {
     namespace = "com.example.my_flutter_app"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    // Match USB serial plugin requirements
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-feature android:name="android.hardware.usb.host" />
     <uses-permission android:name="android.permission.USB_PERMISSION" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <application
         android:label="my_flutter_app"
         android:name="${applicationName}"

--- a/lib/directory_picker.dart
+++ b/lib/directory_picker.dart
@@ -1,0 +1,68 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:path/path.dart' as p;
+
+/// A simple directory picker that lets the user navigate directories
+/// starting from [initialDirectory] and select a destination directory.
+class DirectoryPicker extends StatefulWidget {
+  final Directory initialDirectory;
+  const DirectoryPicker({super.key, required this.initialDirectory});
+
+  @override
+  State<DirectoryPicker> createState() => _DirectoryPickerState();
+}
+
+class _DirectoryPickerState extends State<DirectoryPicker> {
+  late Directory _dir;
+  List<Directory> _subDirs = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _dir = widget.initialDirectory;
+    _refresh();
+  }
+
+  Future<void> _refresh() async {
+    final entries = await _dir.list().whereType<Directory>().toList();
+    entries.sort(
+      (a, b) => p.basename(a.path).toLowerCase().compareTo(
+            p.basename(b.path).toLowerCase(),
+          ),
+    );
+    setState(() => _subDirs = entries);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(p.basename(_dir.path))),
+      body: RefreshIndicator(
+        onRefresh: _refresh,
+        child: ListView.builder(
+          itemCount: _subDirs.length,
+          itemBuilder: (context, index) {
+            final d = _subDirs[index];
+            return ListTile(
+              leading: const Icon(Icons.folder),
+              title: Text(p.basename(d.path)),
+              onTap: () => Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => DirectoryPicker(initialDirectory: d),
+                ),
+              ).then((value) {
+                if (value != null) Navigator.pop(context, value);
+              }),
+            );
+          },
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => Navigator.pop(context, _dir),
+        child: const Icon(Icons.check),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 import 'package:usb_serial/usb_serial.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'storage_browser.dart';
 
 void main() {
@@ -40,7 +41,16 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   void initState() {
     super.initState();
-    _scanStorage();
+    _ensurePermission();
+  }
+
+  Future<void> _ensurePermission() async {
+    final status = await Permission.storage.request();
+    if (status.isGranted) {
+      _scanStorage();
+    } else {
+      setState(() => _status = 'Storage permission denied');
+    }
   }
 
   Future<void> _scanStorage() async {

--- a/lib/storage_browser.dart
+++ b/lib/storage_browser.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:path/path.dart' as p;
+import 'directory_picker.dart';
 
 class StorageBrowser extends StatefulWidget {
   final Directory directory;
@@ -36,7 +37,14 @@ class _StorageBrowserState extends State<StorageBrowser> {
     final result = await FilePicker.platform.pickFiles();
     if (result == null || result.files.single.path == null) return;
     final src = File(result.files.single.path!);
-    final dest = File(p.join(_dir.path, p.basename(src.path)));
+    final destDir = await Navigator.push<Directory?>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => DirectoryPicker(initialDirectory: _dir),
+      ),
+    );
+    if (destDir == null) return;
+    final dest = File(p.join(destDir.path, p.basename(src.path)));
     await src.copy(dest.path);
     _refresh();
   }

--- a/lib/storage_browser.dart
+++ b/lib/storage_browser.dart
@@ -25,6 +25,8 @@ class _StorageBrowserState extends State<StorageBrowser> {
 
   Future<void> _refresh() async {
     final items = await _dir.list().toList();
+    items.sort((a, b) =>
+        p.basename(a.path).toLowerCase().compareTo(p.basename(b.path).toLowerCase()));
     setState(() {
       _items = items;
     });

--- a/lib/storage_browser.dart
+++ b/lib/storage_browser.dart
@@ -1,0 +1,122 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:path/path.dart' as p;
+
+class StorageBrowser extends StatefulWidget {
+  final Directory directory;
+  const StorageBrowser({super.key, required this.directory});
+
+  @override
+  State<StorageBrowser> createState() => _StorageBrowserState();
+}
+
+class _StorageBrowserState extends State<StorageBrowser> {
+  late Directory _dir;
+  List<FileSystemEntity> _items = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _dir = widget.directory;
+    _refresh();
+  }
+
+  Future<void> _refresh() async {
+    final items = await _dir.list().toList();
+    setState(() {
+      _items = items;
+    });
+  }
+
+  Future<void> _addFile() async {
+    final result = await FilePicker.platform.pickFiles();
+    if (result == null || result.files.single.path == null) return;
+    final src = File(result.files.single.path!);
+    final dest = File(p.join(_dir.path, p.basename(src.path)));
+    await src.copy(dest.path);
+    _refresh();
+  }
+
+  Future<void> _delete(FileSystemEntity entity) async {
+    await entity.delete(recursive: true);
+    _refresh();
+  }
+
+  Future<void> _rename(FileSystemEntity entity) async {
+    final TextEditingController controller =
+        TextEditingController(text: p.basename(entity.path));
+    final newName = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Rename'),
+        content: TextField(controller: controller),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text('Cancel')),
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, controller.text),
+              child: const Text('OK')),
+        ],
+      ),
+    );
+    if (newName == null || newName.isEmpty) return;
+    final newPath = p.join(_dir.path, newName);
+    if (entity is File) {
+      await entity.rename(newPath);
+    } else if (entity is Directory) {
+      await entity.rename(newPath);
+    }
+    _refresh();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(p.basename(_dir.path))),
+      body: RefreshIndicator(
+        onRefresh: _refresh,
+        child: ListView.builder(
+          itemCount: _items.length,
+          itemBuilder: (context, index) {
+            final item = _items[index];
+            final isDir = item is Directory;
+            return ListTile(
+              leading: Icon(isDir ? Icons.folder : Icons.insert_drive_file),
+              title: Text(p.basename(item.path)),
+              onTap: isDir
+                  ? () => Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => StorageBrowser(
+                            directory: Directory(item.path),
+                          ),
+                        ),
+                      )
+                  : null,
+              trailing: PopupMenuButton<String>(
+                onSelected: (v) {
+                  if (v == 'delete') {
+                    _delete(item);
+                  } else if (v == 'rename') {
+                    _rename(item);
+                  }
+                },
+                itemBuilder: (_) => const [
+                  PopupMenuItem(value: 'delete', child: Text('Delete')),
+                  PopupMenuItem(value: 'rename', child: Text('Rename')),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _addFile,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,8 @@ dependencies:
     sdk: flutter
   http: ^0.13.6
   usb_serial: ^0.4.0
+  file_picker: ^6.1.1
+  path: ^1.8.3
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   usb_serial: ^0.4.0
   file_picker: ^6.1.1
   path: ^1.8.3
+  permission_handler: ^11.0.0
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8


### PR DESCRIPTION
## Summary
- add `file_picker` and `path` dependencies
- create `StorageBrowser` widget for browsing directories
- list external storage directories on the home page and allow basic file operations
- document behaviour in README

## Testing
- `git status --short`
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68873c215bf8832ab4697c6ed274704e