### PR TITLE
Fix stream filtering and lints

### DIFF
--- a/lib/directory_picker.dart
+++ b/lib/directory_picker.dart
@@ -25,7 +25,11 @@ class _DirectoryPickerState extends State<DirectoryPicker> {
   }
 
   Future<void> _refresh() async {
-    final entries = await _dir.list().whereType<Directory>().toList();
+    final entries = await _dir
+        .list()
+        .where((e) => e is Directory)
+        .cast<Directory>()
+        .toList();
     entries.sort(
       (a, b) => p.basename(a.path).toLowerCase().compareTo(
             p.basename(b.path).toLowerCase(),
@@ -47,14 +51,16 @@ class _DirectoryPickerState extends State<DirectoryPicker> {
             return ListTile(
               leading: const Icon(Icons.folder),
               title: Text(p.basename(d.path)),
-              onTap: () => Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => DirectoryPicker(initialDirectory: d),
-                ),
-              ).then((value) {
+              onTap: () async {
+                final value = await Navigator.push<Directory?>(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => DirectoryPicker(initialDirectory: d),
+                  ),
+                );
+                if (!mounted) return;
                 if (value != null) Navigator.pop(context, value);
-              }),
+              },
             );
           },
         ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -58,7 +58,8 @@ class _MyHomePageState extends State<MyHomePage> {
     if (await root.exists()) {
       final entries = await root
           .list()
-          .whereType<Directory>()
+          .where((e) => e is Directory)
+          .cast<Directory>()
           .toList();
       final filtered = entries.where((d) {
         final name = p.basename(d.path);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:usb_serial/usb_serial.dart';
 
 import 'storage_browser.dart';
+import 'directory_picker.dart';
 
 void main() {
   runApp(const MyApp());
@@ -41,6 +42,7 @@ class _MyHomePageState extends State<MyHomePage> {
   String _status = "Idle";
   List<Directory> _devices = [];
   File? _selectedFile;
+  Directory? _outputDir;
 
   @override
   void initState() {
@@ -78,6 +80,23 @@ class _MyHomePageState extends State<MyHomePage> {
     if (!mounted) return;
     if (result != null && result.files.single.path != null) {
       setState(() => _selectedFile = File(result.files.single.path!));
+    }
+  }
+
+  Future<void> _selectOutputDirectory() async {
+    if (_devices.isEmpty) {
+      setState(() => _status = 'No external storage detected');
+      return;
+    }
+    final dir = await Navigator.push<Directory?>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => DirectoryPicker(initialDirectory: _devices.first),
+      ),
+    );
+    if (!mounted) return;
+    if (dir != null) {
+      setState(() => _outputDir = dir);
     }
   }
 
@@ -162,6 +181,19 @@ class _MyHomePageState extends State<MyHomePage> {
                     padding: const EdgeInsets.only(top: 8.0),
                     child: Text(
                       p.basename(_selectedFile!.path),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                const SizedBox(height: 12),
+                ElevatedButton(
+                  onPressed: _selectOutputDirectory,
+                  child: const Text('Select Output'),
+                ),
+                if (_outputDir != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8.0),
+                    child: Text(
+                      _outputDir!.path,
                       overflow: TextOverflow.ellipsis,
                     ),
                   ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,13 @@
 import 'dart:io';
 import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
-import 'package:usb_serial/usb_serial.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:usb_serial/usb_serial.dart';
+
 import 'storage_browser.dart';
 
 void main() {
@@ -37,6 +40,7 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   String _status = "Idle";
   List<Directory> _devices = [];
+  File? _selectedFile;
 
   @override
   void initState() {
@@ -66,6 +70,14 @@ class _MyHomePageState extends State<MyHomePage> {
         return name != 'self' && name != 'emulated';
       }).toList();
       setState(() => _devices = filtered);
+    }
+  }
+
+  Future<void> _pickFile() async {
+    final result = await FilePicker.platform.pickFiles();
+    if (!mounted) return;
+    if (result != null && result.files.single.path != null) {
+      setState(() => _selectedFile = File(result.files.single.path!));
     }
   }
 
@@ -140,6 +152,19 @@ class _MyHomePageState extends State<MyHomePage> {
                   onPressed: () => downloadAndSendToUsb(fileUrl),
                   child: const Text("Download & Upload to USB"),
                 ),
+                const SizedBox(height: 12),
+                ElevatedButton(
+                  onPressed: _pickFile,
+                  child: const Text('Select File'),
+                ),
+                if (_selectedFile != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8.0),
+                    child: Text(
+                      p.basename(_selectedFile!.path),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
               ],
             ),
           ),

--- a/lib/storage_browser.dart
+++ b/lib/storage_browser.dart
@@ -35,6 +35,7 @@ class _StorageBrowserState extends State<StorageBrowser> {
 
   Future<void> _addFile() async {
     final result = await FilePicker.platform.pickFiles();
+    if (!mounted) return;
     if (result == null || result.files.single.path == null) return;
     final src = File(result.files.single.path!);
     final destDir = await Navigator.push<Directory?>(
@@ -43,6 +44,7 @@ class _StorageBrowserState extends State<StorageBrowser> {
         builder: (_) => DirectoryPicker(initialDirectory: _dir),
       ),
     );
+    if (!mounted) return;
     if (destDir == null) return;
     final dest = File(p.join(destDir.path, p.basename(src.path)));
     await src.copy(dest.path);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,12 +42,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  http: ^0.13.6
-  usb_serial: ^0.5.2
-  file_picker: ^10.2.0
-  path: ^1.9.1
-  permission_handler: ^12.0.1
-  cupertino_icons: ^1.0.8
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is
   # activated in the `analysis_options.yaml` file located at the root of your


### PR DESCRIPTION
## Summary
- filter `Stream` entries without using `whereType`
- avoid using BuildContext across async gaps
- remove duplicate dev dependencies

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688743cada88832aa3fef687ac3b6f68