### PR TITLE
Add SAF stub and fix lint

### DIFF
--- a/lib/directory_picker.dart
+++ b/lib/directory_picker.dart
@@ -58,7 +58,7 @@ class _DirectoryPickerState extends State<DirectoryPicker> {
                     builder: (_) => DirectoryPicker(initialDirectory: d),
                   ),
                 );
-                if (!mounted) return;
+                if (!context.mounted) return;
                 if (value != null) Navigator.pop(context, value);
               },
             );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,7 +7,7 @@ import 'package:path/path.dart' as p;
 import 'package:permission_handler/permission_handler.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:device_info_plus/device_info_plus.dart';
-import 'package:saf/saf.dart';
+import 'saf_stub.dart';
 
 import 'storage_browser.dart';
 

--- a/lib/saf_stub.dart
+++ b/lib/saf_stub.dart
@@ -1,0 +1,30 @@
+import "dart:io";
+import "package:path/path.dart" as path;
+class Saf {
+  /// Opens the system directory picker and returns the selected URI.
+  static Future<String?> openDocumentTree() async {
+    // This stub simply returns null as no directory can be chosen
+    return null;
+  }
+
+  /// Persists the read/write permissions for the provided [uri].
+  static Future<bool> persistPermissions(String uri) async {
+    // Always return false in the stub implementation.
+    return false;
+  }
+
+  /// Writes [bytes] as [name] into the directory represented by [uri].
+  /// This stub writes to the local filesystem when the [uri] scheme is `file`.
+  static Future<void> writeToFile({
+    required String uri,
+    required String name,
+    required List<int> bytes,
+  }) async {
+    final parsed = Uri.tryParse(uri);
+    if (parsed != null && parsed.scheme == 'file') {
+      final file = File(path.join(parsed.toFilePath(), name));
+      await file.create(recursive: true);
+      await file.writeAsBytes(bytes, flush: true);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a local `Saf` stub so the project can build without the `saf` plugin
- fix `use_build_context_synchronously` lint in `DirectoryPicker`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688792aa2e80832a9f5f8d5c91b69147