### PR TITLE
Switch to document_file_save_plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ adding a file you can browse the external storage to choose the exact
 destination directory.
 
 The app uses the `permission_handler` plugin to request storage access on
-Android 10 and below. For Android 11 and later it relies on the `saf`
-package to request a directory using the Storage Access Framework. Grant
+Android 10 and below. For Android 11 and later it relies on the
+`document_file_save_plus` package to request a directory using the
+Storage Access Framework. Grant
 permission when prompted so the app can write to removable drives.
 You can pick any file using the system file picker via **Select File**.
 The **Select Output** button now opens the system directory picker so you can

--- a/lib/document_file_save_plus_stub.dart
+++ b/lib/document_file_save_plus_stub.dart
@@ -1,9 +1,10 @@
-import "dart:io";
-import "package:path/path.dart" as path;
-class Saf {
+import 'dart:io';
+import 'package:path/path.dart' as path;
+
+class DocumentFileSavePlus {
   /// Opens the system directory picker and returns the selected URI.
   static Future<String?> openDocumentTree() async {
-    // This stub simply returns null as no directory can be chosen
+    // Stub returns null since no directory can be chosen here.
     return null;
   }
 
@@ -14,7 +15,7 @@ class Saf {
   }
 
   /// Writes [bytes] as [name] into the directory represented by [uri].
-  /// This stub writes to the local filesystem when the [uri] scheme is `file`.
+  /// If [uri] uses the file scheme this simply writes to the local filesystem.
   static Future<void> writeToFile({
     required String uri,
     required String name,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,7 +7,7 @@ import 'package:path/path.dart' as p;
 import 'package:permission_handler/permission_handler.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:device_info_plus/device_info_plus.dart';
-import 'saf_stub.dart';
+import 'document_file_save_plus_stub.dart';
 
 import 'storage_browser.dart';
 
@@ -149,10 +149,10 @@ class _MyHomePageState extends State<MyHomePage> {
   Future<void> _selectOutputDirectory() async {
     final sdk = await _androidVersion();
     if (Platform.isAndroid && sdk >= 30) {
-      final uri = await Saf.openDocumentTree();
+      final uri = await DocumentFileSavePlus.openDocumentTree();
       if (!mounted) return;
       if (uri != null) {
-        final granted = await Saf.persistPermissions(uri);
+        final granted = await DocumentFileSavePlus.persistPermissions(uri);
         if (granted) {
           setState(() {
             _outputUri = Uri.parse(uri);
@@ -203,12 +203,12 @@ class _MyHomePageState extends State<MyHomePage> {
     final sdk = await _androidVersion();
     if (Platform.isAndroid && sdk >= 30 && _outputUri != null) {
       try {
-        await Saf.writeToFile(
+        await DocumentFileSavePlus.writeToFile(
           uri: _outputUri!.toString(),
           name: fileName,
           bytes: bytes,
         );
-        setState(() => _status = 'File copied using SAF');
+        setState(() => _status = 'File copied using DocumentFileSavePlus');
       } catch (e) {
         setState(() => _status = 'Failed to copy file: $e');
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   permission_handler: ^10.2.0
   path_provider: ^2.1.5
   device_info_plus: ^10.1.0
-  saf: ^1.0.3+3
+  document_file_save_plus: ^2.0.0
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8


### PR DESCRIPTION
## Summary
- replace `saf` with `document_file_save_plus`
- update README and dependencies
- stub out new plugin API

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68879ede2dd8832ab6c07cb36e786b6d